### PR TITLE
Make the TCP and Websocket ports configurable

### DIFF
--- a/proxy/build.gradle
+++ b/proxy/build.gradle
@@ -31,6 +31,7 @@ dependencies {
   implementation 'io.rsocket:rsocket-micrometer:1.0.0-RC3'
   implementation 'io.rsocket:rsocket-transport-netty:1.0.0-RC3'
   implementation 'org.xerial.snappy:snappy-java:latest.release'
+  annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
   testImplementation 'org.springframework.boot:spring-boot-starter-test'
   testImplementation 'io.projectreactor:reactor-test'

--- a/proxy/src/main/java/io/micrometer/prometheus/rsocket/PrometheusControllerProperties.java
+++ b/proxy/src/main/java/io/micrometer/prometheus/rsocket/PrometheusControllerProperties.java
@@ -20,7 +20,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /**
  * @author Christian Tzolov
  */
-@ConfigurationProperties("prometheus.proxy")
+@ConfigurationProperties("micrometer.prometheus-proxy")
 public class PrometheusControllerProperties {
 
   /**

--- a/proxy/src/main/java/io/micrometer/prometheus/rsocket/PrometheusControllerProperties.java
+++ b/proxy/src/main/java/io/micrometer/prometheus/rsocket/PrometheusControllerProperties.java
@@ -15,14 +15,37 @@
  */
 package io.micrometer.prometheus.rsocket;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@SpringBootApplication
-@EnableConfigurationProperties(PrometheusControllerProperties.class)
-public class PrometheusRSocketProxyMain {
-  public static void main(String[] args) {
-    SpringApplication.run(PrometheusRSocketProxyMain.class, args);
+/**
+ * @author Christian Tzolov
+ */
+@ConfigurationProperties("prometheus.proxy")
+public class PrometheusControllerProperties {
+
+  /**
+   * Proxy accept TCP port.
+   */
+  private int tcpPort = 7001;
+
+  /**
+   * Proxy accept Websocket port.
+   */
+  private int websocketPort = 8081;
+
+  public int getTcpPort() {
+    return tcpPort;
+  }
+
+  public void setTcpPort(int tcpPort) {
+    this.tcpPort = tcpPort;
+  }
+
+  public int getWebsocketPort() {
+    return websocketPort;
+  }
+
+  public void setWebsocketPort(int websocketPort) {
+    this.websocketPort = websocketPort;
   }
 }


### PR DESCRIPTION
 - add prometheus.proxy.tcpPort to configure the TCP accept port. Defaults to 7001.
 - add prometheus.proxy.websocketPort to configure the Websocket accept port. Defaults to 8081.

 Resolves #25