### PR TITLE
Support configuring transport and secure in the starter

### DIFF
--- a/starter-spring/build.gradle
+++ b/starter-spring/build.gradle
@@ -28,4 +28,5 @@ dependencies {
 
   testImplementation 'org.springframework.boot:spring-boot-starter-test'
   testImplementation 'io.projectreactor:reactor-test'
+  testImplementation 'io.micrometer:micrometer-registry-prometheus'
 }

--- a/starter-spring/src/main/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketAutoConfiguration.java
+++ b/starter-spring/src/main/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketAutoConfiguration.java
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.micrometer.prometheus.rsocket.autoconfigure;
 
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.micrometer.prometheus.rsocket.PrometheusRSocketClient;
-import io.rsocket.transport.netty.client.TcpClientTransport;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.prometheus.PrometheusMetricsExportAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -37,8 +37,7 @@ public class PrometheusRSocketAutoConfiguration {
   @ConditionalOnMissingBean
   @Bean(destroyMethod = "pushAndClose")
   PrometheusRSocketClient prometheusRSocketClient(PrometheusMeterRegistry meterRegistry, PrometheusRSocketProperties properties) {
-    return new PrometheusRSocketClient(meterRegistry,
-      TcpClientTransport.create(properties.getHost(), properties.getPort()),
+    return new PrometheusRSocketClient(meterRegistry, properties.createClientTransport(),
       c -> c.retryBackoff(properties.getMaxRetries(), properties.getFirstBackoff(), properties.getMaxBackoff()));
   }
 }

--- a/starter-spring/src/main/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketProperties.java
+++ b/starter-spring/src/main/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketProperties.java
@@ -31,7 +31,7 @@ public class PrometheusRSocketProperties {
   /**
    * The host name of the proxy to connect to.
    */
-  private String host;
+  private String host = "localhost";
 
   /**
    * The port to make a connection on.

--- a/starter-spring/src/test/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketAutoConfigurationTest.java
+++ b/starter-spring/src/test/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketAutoConfigurationTest.java
@@ -64,8 +64,7 @@ public class PrometheusRSocketAutoConfigurationTest {
     final CountDownLatch latch = new CountDownLatch(1);
     this.startServer(TcpServerTransport.create(port), latch)
         .block();
-    this.contextRunner.withPropertyValues("management.metrics.export.prometheus.rsocket.host=localhost",
-        "management.metrics.export.prometheus.rsocket.port=" + port,
+    this.contextRunner.withPropertyValues("management.metrics.export.prometheus.rsocket.port=" + port,
         "management.metrics.export.prometheus.rsocket.transport=tcp")
         .run(context -> {
           latch.await(5, TimeUnit.SECONDS);
@@ -79,8 +78,7 @@ public class PrometheusRSocketAutoConfigurationTest {
     final CountDownLatch latch = new CountDownLatch(1);
     this.startServer(WebsocketServerTransport.create(port), latch)
         .block();
-    this.contextRunner.withPropertyValues("management.metrics.export.prometheus.rsocket.host=localhost",
-        "management.metrics.export.prometheus.rsocket.port=" + port,
+    this.contextRunner.withPropertyValues("management.metrics.export.prometheus.rsocket.port=" + port,
         "management.metrics.export.prometheus.rsocket.transport=websocket")
         .run(context -> {
           latch.await(5, TimeUnit.SECONDS);

--- a/starter-spring/src/test/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketAutoConfigurationTest.java
+++ b/starter-spring/src/test/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketAutoConfigurationTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.prometheus.rsocket.autoconfigure;
+
+import io.rsocket.AbstractRSocket;
+import io.rsocket.Payload;
+import io.rsocket.RSocketFactory;
+import io.rsocket.transport.ServerTransport;
+import io.rsocket.transport.netty.server.CloseableChannel;
+import io.rsocket.transport.netty.server.TcpServerTransport;
+import io.rsocket.transport.netty.server.WebsocketServerTransport;
+import org.junit.Test;
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.prometheus.PrometheusMetricsExportAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.util.SocketUtils;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PrometheusRSocketAutoConfigurationTest {
+
+  private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+      .withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class, PrometheusMetricsExportAutoConfiguration.class, PrometheusRSocketAutoConfiguration.class));
+
+  private Mono<CloseableChannel> startServer(ServerTransport<CloseableChannel> serverTransport, CountDownLatch latch) {
+    return RSocketFactory.receive()
+        .acceptor((setup, sendingSocket) -> {
+          latch.countDown();
+          final AbstractRSocket rsocket = new AbstractRSocket() {
+
+            @Override
+            public Mono<Void> fireAndForget(Payload payload) {
+              return Mono.empty();
+            }
+          };
+          return Mono.just(rsocket);
+        })
+        .transport(serverTransport)
+        .start();
+  }
+
+  @Test
+  public void prometheusRSocketClientTcp() {
+    int port = SocketUtils.findAvailableTcpPort();
+    final CountDownLatch latch = new CountDownLatch(1);
+    this.startServer(TcpServerTransport.create(port), latch)
+        .block();
+    this.contextRunner.withPropertyValues("management.metrics.export.prometheus.rsocket.host=localhost",
+        "management.metrics.export.prometheus.rsocket.port=" + port,
+        "management.metrics.export.prometheus.rsocket.transport=tcp")
+        .run(context -> {
+          latch.await(5, TimeUnit.SECONDS);
+          assertThat(latch.getCount()).isEqualTo(0);
+        });
+  }
+
+  @Test
+  public void prometheusRSocketClientWebsocket() {
+    int port = SocketUtils.findAvailableTcpPort();
+    final CountDownLatch latch = new CountDownLatch(1);
+    this.startServer(WebsocketServerTransport.create(port), latch)
+        .block();
+    this.contextRunner.withPropertyValues("management.metrics.export.prometheus.rsocket.host=localhost",
+        "management.metrics.export.prometheus.rsocket.port=" + port,
+        "management.metrics.export.prometheus.rsocket.transport=websocket")
+        .run(context -> {
+          latch.await(5, TimeUnit.SECONDS);
+          assertThat(latch.getCount()).isEqualTo(0);
+        });
+  }
+}

--- a/starter-spring/src/test/resources/logback.xml
+++ b/starter-spring/src/test/resources/logback.xml
@@ -1,0 +1,10 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %5p --- [%15.15t] %-40.40logger{39} : %m%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/starter-spring/src/test/resources/logback.xml
+++ b/starter-spring/src/test/resources/logback.xml
@@ -1,3 +1,18 @@
+<!--
+ Copyright 2019 Pivotal Software, Inc.
+ <p>
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ <p>
+ https://www.apache.org/licenses/LICENSE-2.0
+ <p>
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>


### PR DESCRIPTION
This PR adds 
* `management.metrics.export.prometheus.rsocket.transport` 
* `management.metrics.export.prometheus.rsocket.secure` 

so that client apps that uses the starter can configure WebSocket protocol. 


I have tested it worked with following properties 
```properties
management.metrics.export.prometheus.rsocket.host=prometheus-proxy-ws.cfapps.io
management.metrics.export.prometheus.rsocket.transport=websocket
management.metrics.export.prometheus.rsocket.port=8443
management.metrics.export.prometheus.rsocket.secure=true

# the endpoint to scape is https://prometheus-proxy-scrape.cfapps.io/metrics/proxy
```
