### PR TITLE
Client autoconfiguration should be conditional on PrometheusMeterRegistry bean 

### DIFF
--- a/proxy/src/main/java/io/micrometer/prometheus/rsocket/PrometheusRSocketProxyMain.java
+++ b/proxy/src/main/java/io/micrometer/prometheus/rsocket/PrometheusRSocketProxyMain.java
@@ -16,10 +16,11 @@
 package io.micrometer.prometheus.rsocket;
 
 import io.micrometer.prometheus.rsocket.autoconfigure.EnablePrometheusRSocketProxyServer;
+import io.micrometer.prometheus.rsocket.autoconfigure.PrometheusRSocketClientAutoConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = PrometheusRSocketClientAutoConfiguration.class)
 @EnablePrometheusRSocketProxyServer
 public class PrometheusRSocketProxyMain {
   public static void main(String[] args) {

--- a/starter-spring/src/main/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientAutoConfiguration.java
+++ b/starter-spring/src/main/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientAutoConfiguration.java
@@ -20,7 +20,7 @@ import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.micrometer.prometheus.rsocket.PrometheusRSocketClient;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.prometheus.PrometheusMetricsExportAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -30,7 +30,7 @@ import reactor.util.retry.Retry;
 
 @Configuration
 @AutoConfigureAfter(PrometheusMetricsExportAutoConfiguration.class)
-@ConditionalOnClass(PrometheusMeterRegistry.class)
+@ConditionalOnBean(PrometheusMeterRegistry.class)
 @ConditionalOnProperty(prefix = "management.metrics.export.prometheus.rsocket", name = "enabled", havingValue = "true", matchIfMissing = true)
 @EnableConfigurationProperties(PrometheusRSocketClientProperties.class)
 public class PrometheusRSocketClientAutoConfiguration {


### PR DESCRIPTION
Two fixes post 1.2.0:

1. 
**Issue**:  It was discovered that the PrometheusRSocketProxy unintentionally loads the client on startup. This was not happening before 1.2.0 and is caused by the dependency on starter-spring. 
**fix**: An exclusion was added to the `SpringBootApplication` annotation.

2. 
**issue**: Some users of the `prometheus-rsocket-spring` may notice context loading issues after the beans marked as `ConditionalOnMissingBean` were removed in 1.2.0. (Note this was mainly observed in tests that require a spring context but were not expecting to use a micrometer registry.) 
**fix**: Changing `ConditionalOnClass` to `ConditionalOnBean` on  `PrometheusRSocketClientAutoConfiguration` allows client apps to remain passive without having to add additional configuration to disable client autoconfiguration. 

I'm happy to make other changes as needed. 