### PR TITLE
Configure proxyBeanMethods = false on PrometheusRSocketClientAutoConfiguration

### DIFF
--- a/starter-spring/src/main/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientAutoConfiguration.java
+++ b/starter-spring/src/main/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientAutoConfiguration.java
@@ -28,7 +28,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import reactor.util.retry.Retry;
 
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @AutoConfigureAfter(PrometheusMetricsExportAutoConfiguration.class)
 @ConditionalOnBean(PrometheusMeterRegistry.class)
 @ConditionalOnProperty(prefix = "management.metrics.export.prometheus.rsocket", name = "enabled", havingValue = "true", matchIfMissing = true)


### PR DESCRIPTION
as same as other config classes in the same package.

Without this configuration, creating a native image fails with spring-graal-native.