### PR TITLE
Set scrape timeout based on Prometheus header

### DIFF
--- a/proxy-server/src/main/java/io/micrometer/prometheus/rsocket/PrometheusControllerProperties.java
+++ b/proxy-server/src/main/java/io/micrometer/prometheus/rsocket/PrometheusControllerProperties.java
@@ -17,11 +17,15 @@ package io.micrometer.prometheus.rsocket;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.time.Duration;
+
 /**
  * @author Christian Tzolov
  */
 @ConfigurationProperties("micrometer.prometheus-proxy")
 public class PrometheusControllerProperties {
+
+  private static final Duration DEFAULT_TIMEOUT_OFFSET = Duration.ZERO;
 
   /**
    * Proxy accept TCP port.
@@ -32,6 +36,11 @@ public class PrometheusControllerProperties {
    * Proxy accept Websocket port.
    */
   private int websocketPort = 8081;
+
+  /**
+   * Scrape timeout offset.
+   */
+  private Duration timeoutOffset = DEFAULT_TIMEOUT_OFFSET;
 
   public int getTcpPort() {
     return tcpPort;
@@ -47,5 +56,17 @@ public class PrometheusControllerProperties {
 
   public void setWebsocketPort(int websocketPort) {
     this.websocketPort = websocketPort;
+  }
+
+  public Duration getTimeoutOffset() {
+    return timeoutOffset;
+  }
+
+  public void setTimeoutOffset(Duration timeoutOffset) {
+    if (timeoutOffset == null || timeoutOffset.isNegative()) {
+      this.timeoutOffset = DEFAULT_TIMEOUT_OFFSET;
+    } else {
+      this.timeoutOffset = timeoutOffset;
+    }
   }
 }


### PR DESCRIPTION
This PR sets the proxy timeout for individual instances based on the value of the `X-Prometheus-Scrape-Timeout-Seconds` header (set by Prometheus since `v1.6.0`) minus a configurable offset.

Currently, a _single_ connected instance failing to respond before the Prometheus scrape timeout (due to very high CPU or some other issue) will cause metrics not to be scraped from _all_ of the connected instances. Thus, setting an instance scrape timeout slightly less than the Prometheus scrape timeout allows for dealing with these type of situations which are exceedingly common in large environments with hundreds to thousands of connected instances.

Note that I set the default timeout offset to 0 to maintain backwards compatibility, but I'd be happy to set it to a value like `1s` that's beneficial by default.