### PR TITLE
Add micrometer.prometheus-proxy.connected-metrics-metadata property

### DIFF
--- a/proxy-server/src/main/java/io/micrometer/prometheus/rsocket/PrometheusControllerProperties.java
+++ b/proxy-server/src/main/java/io/micrometer/prometheus/rsocket/PrometheusControllerProperties.java
@@ -33,6 +33,12 @@ public class PrometheusControllerProperties {
    */
   private int websocketPort = 8081;
 
+  /**
+   * Whether to enable publishing of Prometheus metadata (lines "# HELP ..." and lines "# TYPE ...") in the payload returned by the /metrics/connected endpoint.
+   * Disabling metadata publishing reduces the amount of data sent sent on each scrape.
+   */
+  private boolean connectedMetricsMetadata = true;
+
   public int getTcpPort() {
     return tcpPort;
   }
@@ -47,5 +53,13 @@ public class PrometheusControllerProperties {
 
   public void setWebsocketPort(int websocketPort) {
     this.websocketPort = websocketPort;
+  }
+
+  public boolean getConnectedMetricsMetadata() {
+    return connectedMetricsMetadata;
+  }
+
+  public void setConnectedMetricsMetadata(boolean connectedMetricsMetadata) {
+    this.connectedMetricsMetadata = connectedMetricsMetadata;
   }
 }


### PR DESCRIPTION
Add **micrometer.prometheus-proxy.connected-metrics-metadata** property to enable or disable publishing of Prometheus metadata (lines "# HELP ..." and lines "# TYPE ...") in the payload returned by the /metrics/connected endpoint. The default value is True.

Disabling metadata publishing reduces the amount of data sent sent on each scrape.

In addition, some clients such as Telegarf expect the "# HELP ..." lines to be unique. 
Currently, collecting metrics reported by the /metrics/connected endpoint fails with a Telegarf agent:
_"parsing metrics failed: reading text format failed: text format parsing error in line XX: second HELP line for metric name"_ 

Disabling metrics metadata allows to work around this problem and scrapping the /metrics/connected endpoint with a Telegraf agent works well.