### PR TITLE
Update the PrometheusRSocketClientProperties prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ or
 This will autoconfigure the Micrometer `PrometheusMeterRegistry`, a `PrometheusRSocketClient`, and a call to `pushAndClose` on application shutdown. The client will be configured to retry failing connections to the proxy. Retrying can be tuned with:
 
 ```yml
-management.metrics.export.prometheus.rsocket:
+management.prometheus.metrics.export.rsocket:
   host: YOURPROXYHOSTHERE #required
   port: 7001
   max-retries: 10000 # default is Long.MAX_VALUE

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ or
 This will autoconfigure the Micrometer `PrometheusMeterRegistry`, a `PrometheusRSocketClient`, and a call to `pushAndClose` on application shutdown. The client will be configured to retry failing connections to the proxy. Retrying can be tuned with:
 
 ```yml
-management.prometheus.metrics.export.rsocket:
+micrometer.prometheus.rsocket:
   host: YOURPROXYHOSTHERE #required
   port: 7001
   max-retries: 10000 # default is Long.MAX_VALUE

--- a/starter-spring/src/main/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientAutoConfiguration.java
+++ b/starter-spring/src/main/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientAutoConfiguration.java
@@ -31,7 +31,7 @@ import reactor.util.retry.Retry;
 @AutoConfiguration
 @AutoConfigureAfter(PrometheusMetricsExportAutoConfiguration.class)
 @ConditionalOnBean(PrometheusMeterRegistry.class)
-@ConditionalOnProperty(prefix = "management.metrics.export.prometheus.rsocket", name = "enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(prefix = "management.prometheus.metrics.export.rsocket", name = "enabled", havingValue = "true", matchIfMissing = true)
 @EnableConfigurationProperties(PrometheusRSocketClientProperties.class)
 public class PrometheusRSocketClientAutoConfiguration {
 

--- a/starter-spring/src/main/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientAutoConfiguration.java
+++ b/starter-spring/src/main/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientAutoConfiguration.java
@@ -31,7 +31,7 @@ import reactor.util.retry.Retry;
 @AutoConfiguration
 @AutoConfigureAfter(PrometheusMetricsExportAutoConfiguration.class)
 @ConditionalOnBean(PrometheusMeterRegistry.class)
-@ConditionalOnProperty(prefix = "management.prometheus.metrics.export.rsocket", name = "enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(prefix = "micrometer.prometheus.rsocket", name = "enabled", havingValue = "true", matchIfMissing = true)
 @EnableConfigurationProperties(PrometheusRSocketClientProperties.class)
 public class PrometheusRSocketClientAutoConfiguration {
 

--- a/starter-spring/src/main/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientProperties.java
+++ b/starter-spring/src/main/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientProperties.java
@@ -25,7 +25,7 @@ import reactor.netty.tcp.TcpClient;
 
 import java.time.Duration;
 
-@ConfigurationProperties("management.metrics.export.prometheus.rsocket")
+@ConfigurationProperties("management.prometheus.metrics.export.rsocket")
 public class PrometheusRSocketClientProperties {
 
   /**

--- a/starter-spring/src/main/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientProperties.java
+++ b/starter-spring/src/main/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientProperties.java
@@ -25,7 +25,7 @@ import reactor.netty.tcp.TcpClient;
 
 import java.time.Duration;
 
-@ConfigurationProperties("management.prometheus.metrics.export.rsocket")
+@ConfigurationProperties("micrometer.prometheus.rsocket")
 public class PrometheusRSocketClientProperties {
 
   /**

--- a/starter-spring/src/test/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientAutoConfigurationTest.java
+++ b/starter-spring/src/test/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 20190 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/starter-spring/src/test/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientAutoConfigurationTest.java
+++ b/starter-spring/src/test/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientAutoConfigurationTest.java
@@ -69,8 +69,8 @@ class PrometheusRSocketClientAutoConfigurationTest {
 
     contextRunner
         .withPropertyValues(
-            "management.prometheus.metrics.export.rsocket.port=" + port,
-            "management.prometheus.metrics.export.rsocket.transport=tcp"
+            "micrometer.prometheus.rsocket.port=" + port,
+            "micrometer.prometheus.rsocket.transport=tcp"
         )
         .run(context -> {
           latch.await(5, TimeUnit.SECONDS);
@@ -87,8 +87,8 @@ class PrometheusRSocketClientAutoConfigurationTest {
 
     contextRunner
         .withPropertyValues(
-            "management.prometheus.metrics.export.rsocket.port=" + port,
-            "management.prometheus.metrics.export.rsocket.transport=websocket"
+            "micrometer.prometheus.rsocket.port=" + port,
+            "micrometer.prometheus.rsocket.transport=websocket"
         )
         .run(context -> {
           latch.await(5, TimeUnit.SECONDS);

--- a/starter-spring/src/test/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientAutoConfigurationTest.java
+++ b/starter-spring/src/test/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Pivotal Software, Inc.
+ * Copyright 20190 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,8 +69,8 @@ class PrometheusRSocketClientAutoConfigurationTest {
 
     contextRunner
         .withPropertyValues(
-            "management.metrics.export.prometheus.rsocket.port=" + port,
-            "management.metrics.export.prometheus.rsocket.transport=tcp"
+            "management.prometheus.metrics.export.rsocket.port=" + port,
+            "management.prometheus.metrics.export.rsocket.transport=tcp"
         )
         .run(context -> {
           latch.await(5, TimeUnit.SECONDS);
@@ -87,8 +87,8 @@ class PrometheusRSocketClientAutoConfigurationTest {
 
     contextRunner
         .withPropertyValues(
-            "management.metrics.export.prometheus.rsocket.port=" + port,
-            "management.metrics.export.prometheus.rsocket.transport=websocket"
+            "management.prometheus.metrics.export.rsocket.port=" + port,
+            "management.prometheus.metrics.export.rsocket.transport=websocket"
         )
         .run(context -> {
           latch.await(5, TimeUnit.SECONDS);


### PR DESCRIPTION
This commit updates the prefix of the PrometheusRSocketClientProperties config props to be consistent w/ the metrics config props naming scheme in Spring Boot 3.x.

Specifically, change from `management.metrics.export.prometheus.rsocket` to `management.prometheus.metrics.export.rsocket`.