### PR TITLE
feat: timeout configuration for client

### DIFF
--- a/starter-spring/src/main/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientAutoConfiguration.java
+++ b/starter-spring/src/main/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientAutoConfiguration.java
@@ -41,6 +41,7 @@ public class PrometheusRSocketClientAutoConfiguration {
     return PrometheusRSocketClient.build(meterRegistry, properties.createClientTransport())
         .retry(Retry.backoff(properties.getMaxRetries(), properties.getFirstBackoff())
             .maxBackoff(properties.getMaxBackoff()))
+        .timeout(properties.getTimeout())
         .connectBlockingly();
   }
 }

--- a/starter-spring/src/main/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientProperties.java
+++ b/starter-spring/src/main/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientProperties.java
@@ -63,6 +63,11 @@ public class PrometheusRSocketClientProperties {
    */
   private boolean secure = false;
 
+  /**
+   * The timeout in seconds to be used for establishing the connection and pushing the data
+   */
+  private Duration timeout = Duration.ofSeconds(5);
+
   public long getMaxRetries() {
     return maxRetries;
   }
@@ -117,6 +122,14 @@ public class PrometheusRSocketClientProperties {
 
   public boolean isSecure() {
     return secure;
+  }
+
+  public Duration getTimeout() {
+    return timeout;
+  }
+
+  public void setTimeout(Duration timeout) {
+    this.timeout = timeout;
   }
 
   ClientTransport createClientTransport() {


### PR DESCRIPTION
This PR is going allow the configuration of the timeout for `prometheus-rsocket-proxy-client`to connect to the proxy-server and to push the data to the server.

Fixes: https://github.com/micrometer-metrics/prometheus-rsocket-proxy/issues/86