### PR TITLE
feat: remove ConditionalOnProperty because of native images

### DIFF
--- a/starter-spring/src/main/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientAutoConfiguration.java
+++ b/starter-spring/src/main/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package io.micrometer.prometheus.rsocket.autoconfigure;
 
+import io.micrometer.common.util.internal.logging.InternalLogger;
+import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.prometheus.rsocket.PrometheusRSocketClient;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.prometheus.PrometheusMetricsExportAutoConfiguration;
@@ -23,7 +25,6 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import reactor.util.retry.Retry;
@@ -31,13 +32,21 @@ import reactor.util.retry.Retry;
 @AutoConfiguration
 @AutoConfigureAfter(PrometheusMetricsExportAutoConfiguration.class)
 @ConditionalOnBean(PrometheusMeterRegistry.class)
-@ConditionalOnProperty(prefix = "micrometer.prometheus.rsocket", name = "enabled", havingValue = "true", matchIfMissing = true)
 @EnableConfigurationProperties(PrometheusRSocketClientProperties.class)
 public class PrometheusRSocketClientAutoConfiguration {
+
+  private static final InternalLogger LOGGER = InternalLoggerFactory.getInstance(PrometheusRSocketClientAutoConfiguration.class);
 
   @ConditionalOnMissingBean
   @Bean(destroyMethod = "pushAndCloseBlockingly")
   PrometheusRSocketClient prometheusRSocketClient(PrometheusMeterRegistry meterRegistry, PrometheusRSocketClientProperties properties) {
+
+    if (!properties.isEnabled()) {
+      LOGGER.info("Prometheus RSocket Client is disabled.");
+      return null;
+    }
+
+    LOGGER.info("Building Prometheus RSocket Client.");
     return PrometheusRSocketClient.build(meterRegistry, properties.createClientTransport())
         .retry(Retry.backoff(properties.getMaxRetries(), properties.getFirstBackoff())
             .maxBackoff(properties.getMaxBackoff()))

--- a/starter-spring/src/main/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientProperties.java
+++ b/starter-spring/src/main/java/io/micrometer/prometheus/rsocket/autoconfigure/PrometheusRSocketClientProperties.java
@@ -31,6 +31,11 @@ import java.time.temporal.ChronoUnit;
 public class PrometheusRSocketClientProperties {
 
   /**
+   * If the prometheus proxy client is enabled.
+   */
+  private boolean enabled = true;
+
+  /**
    * The host name of the proxy to connect to.
    */
   private String host = "localhost";
@@ -93,6 +98,14 @@ public class PrometheusRSocketClientProperties {
 
   public void setMaxBackoff(Duration maxBackoff) {
     this.maxBackoff = maxBackoff;
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
   }
 
   public String getHost() {


### PR DESCRIPTION
As of https://docs.spring.io/spring-boot/reference/packaging/native-image/introducing-graalvm-native-images.html#packaging.native-image.introducing-graalvm-native-images.understanding-aot-processing `@ConditionalOnProperty` is not supported in native images.

So my suggestion is that the bean `PrometheusRSocketClient` is only created if the property `micrometer.prometheus.rsocket.enabled` is set to true in the `PrometheusRSocketClientProperties`.

This way you can configure prometheus rsocket proxy during runtime in GraalVM native images, even with env vars via relax binding of Spring Boot.

Beside that everything is working fine within GraalVM native images. 👍 